### PR TITLE
Optimization for image loading.

### DIFF
--- a/include/cinder/ImageFileTinyExr.h
+++ b/include/cinder/ImageFileTinyExr.h
@@ -54,6 +54,7 @@ class ImageTargetFileTinyExr : public ImageTarget {
 	static ImageTargetRef		create( DataTargetRef dataTarget, ImageSourceRef imageSource, ImageTarget::Options options, const std::string &extensionData );
 
 	void*	getRowPointer( int32_t row ) override;
+	int32_t	getRowBytes() const override { return 0; /* TODO */ }
 	void	finalize() override;
 	
 	static void		registerSelf();

--- a/include/cinder/ImageIo.h
+++ b/include/cinder/ImageIo.h
@@ -159,8 +159,10 @@ class ImageTarget : public ImageIo {
 	virtual ~ImageTarget() {};
 
 	virtual void*	getRowPointer( int32_t row ) = 0;
+	virtual int32_t	getRowBytes() const = 0;
 	virtual void	setRow( int32_t row, const void *data ) { throw; }
 	virtual void	finalize() { }
+	virtual bool	isTopDown() const { return false; }
 	
 	class Options {
 	  public:

--- a/include/cinder/ImageTargetFileWic.h
+++ b/include/cinder/ImageTargetFileWic.h
@@ -40,6 +40,7 @@ class ImageTargetFileWic : public ImageTarget {
 	static ImageTargetRef		create( DataTargetRef dataTarget, ImageSourceRef imageSource, ImageTarget::Options options, const std::string &extensionData );
 	
 	void*	getRowPointer( int32_t row ) override;
+	int32_t	getRowBytes() const override { return mRowBytes; }
 	void	finalize() override;
 	
 	static void		registerSelf();

--- a/include/cinder/qtime/QuickTimeUtils.h
+++ b/include/cinder/qtime/QuickTimeUtils.h
@@ -83,6 +83,7 @@ class ImageTargetCvPixelBuffer : public cinder::ImageTarget {
 	~ImageTargetCvPixelBuffer();
 
 	virtual void*		getRowPointer( int32_t row );
+	virtual int32_t		getRowBytes() const override { return mRowBytes; }
 	virtual void		finalize();
 
 	::CVPixelBufferRef	getCvPixelBuffer() const { return mPixelBufferRef; }
@@ -94,7 +95,7 @@ class ImageTargetCvPixelBuffer : public cinder::ImageTarget {
 	void		convertDataToAYpCbCr();
 
 	::CVPixelBufferRef	mPixelBufferRef;
-	size_t				mRowBytes;
+	int32_t				mRowBytes;
 	uint8_t				*mData;
 	bool				mConvertToYpCbCr;
 };
@@ -110,6 +111,7 @@ class ImageTargetGWorld : public cinder::ImageTarget {
 	static ImageTargetGWorldRef createRef( ImageSourceRef imageSource );
 
 	virtual void*		getRowPointer( int32_t row );
+	virtual int32_t		getRowBytes() const override { return mRowBytes; }
 	virtual void		finalize();
 
 	::GWorldPtr			getGWorld() const { return mGWorld; }
@@ -119,7 +121,7 @@ class ImageTargetGWorld : public cinder::ImageTarget {
 	
 	::GWorldPtr			mGWorld;
 	::PixMapHandle		mPixMap;
-	size_t				mRowBytes;
+	int32_t				mRowBytes;
 	uint8_t				*mData;
 };
 

--- a/src/cinder/Channel.cpp
+++ b/src/cinder/Channel.cpp
@@ -38,6 +38,7 @@ class ImageTargetChannel : public ImageTarget {
 	virtual bool hasAlpha() const { return false; }
 	
 	virtual void*	getRowPointer( int32_t row ) { return reinterpret_cast<void*>( mChannel->getData( ivec2( 0, row ) ) ); }
+	virtual int32_t	getRowBytes() const override { return mChannel ? mChannel->getRowBytes() : 0; }
 	
   protected:
 	ImageTargetChannel( ChannelT<T> *channel )

--- a/src/cinder/ImageSourceFileWic.cpp
+++ b/src/cinder/ImageSourceFileWic.cpp
@@ -233,10 +233,16 @@ void ImageSourceFileWic::load( ImageTargetRef target )
 	else
 		mFrame->CopyPixels( NULL, (UINT)mRowBytes, mRowBytes * mHeight, data.get() );
 	
-	const uint8_t *dataPtr = data.get();
-	for( int32_t row = 0; row < mHeight; ++row ) {
-		((*this).*func)( target, row, dataPtr );
-		dataPtr += mRowBytes;
+	if( target->getRowBytes() != mRowBytes || target->getDataType() != mDataType || !target->isTopDown() ) 
+	{
+		const uint8_t *dataPtr = data.get();
+		for( int32_t row = 0; row < mHeight; ++row ) {
+			((*this).*func)( target, row, dataPtr );
+			dataPtr += mRowBytes;
+		}
+	}
+	else {
+		memcpy( target->getRowPointer(0), (void*)data.get(), mRowBytes * mHeight );
 	}
 }
 

--- a/src/cinder/Surface.cpp
+++ b/src/cinder/Surface.cpp
@@ -56,6 +56,7 @@ class ImageTargetSurface : public ImageTarget {
 	virtual bool hasAlpha() const;
 	
 	virtual void*	getRowPointer( int32_t row );
+	virtual int32_t	getRowBytes() const override { return mSurface ? mSurface->getRowBytes() : 0; }
 	
   protected:
 	ImageTargetSurface( SurfaceT<T> *surface );

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -61,6 +61,8 @@ class ImageTargetGlTexture : public ImageTarget {
 	
 	virtual bool	hasAlpha() const { return mHasAlpha; }
 	virtual void*	getRowPointer( int32_t row );
+	virtual int32_t	getRowBytes() const override { return mRowInc; }
+	virtual bool	isTopDown() const override { return mTexture ? mTexture->isTopDown() : false; }
 	
 	void*			getData() const { return mDataBaseAddress; }
 	


### PR DESCRIPTION
When possible, use a simple memcpy instead of calling a conversion function.